### PR TITLE
Reduce necessary import lines for clients

### DIFF
--- a/lollygag/__init__.py
+++ b/lollygag/__init__.py
@@ -1,4 +1,8 @@
 from lollygag.main import run as run
-
-#def run(**kwargs):
-#    r(**kwargs)
+from lollygag.core.crawlers.domain_crawler import DomainCrawler as DomainCrawler
+from lollygag.core.crawlers.crawler import Crawler as Crawler
+from lollygag.core.crawlers.mapper_crawler import MapperCrawler as MapperCrawler
+from lollygag.services.services import Services as Services
+from lollygag.dependency_injection.inject import Inject as Inject
+from lollygag.core.parsers.link_parser import ParseResult as ParseResult
+from lollygag.core.parsers.link_parser import LinkParser as LinkParser

--- a/lollygag/core/crawlers/domain_crawler.py
+++ b/lollygag/core/crawlers/domain_crawler.py
@@ -12,16 +12,25 @@ class DomainCrawler(Crawler):
         super(DomainCrawler, self).__init__(url)
 
     def initialize_status(self, urls):
+        """
+        Extend the base initialize_status to store the domain being crawled.
+        """
         self.domain = get_domain(urls[0])
         super(DomainCrawler, self).initialize_status(urls)
 
     def process_link(self, origin, link):
+        """
+        Extend the base process_link method to only return links that are on the same domain.
+        """
         result = super(DomainCrawler, self).process_link(origin, link)
         if result is None or get_domain(result) != self.domain:
             return None
         return result
 
     def crawl(self, url=None):
+        """
+        Extend the base crawl method to assert if self.domain exists
+        """
         if url:
             self.reset(url)
         assert self.domain, "Cannot start crawling without a domain!"

--- a/test/crawler_example.py
+++ b/test/crawler_example.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 
-from lollygag import run
-from lollygag.services import Services
-from lollygag.core.parsers.link_parser import LinkParser
+from lollygag import run, Services, LinkParser
 
 # Override HTMLParser methods to provide a custom implementation
 # https://docs.python.org/2/library/htmlparser.html


### PR DESCRIPTION
## Proposed Changes

  - Add commonly used modules to the main `__init__.py ` So clients need less import lines to use the library.
  - Update the `crawler_example.py` to reflect these changes
