### PR TITLE
'-u' now optional; generalize startup (main.py) (same for 1 or N); issue #47

### DIFF
--- a/lollygag/main.py
+++ b/lollygag/main.py
@@ -21,18 +21,19 @@ def run(**kwargs):
     register_services()
     config = Inject("config_service").request()
     config.setup()
-    url = kwargs.get('url', config.urls)
-    if len(url) == 1:
-        url = url[0]
     subscriber = None
+    urls = sum(config.urls, [])
+    
     if 'subscribe' in kwargs:
         subscriber = lambda crawler: subscribe_to_crawler(crawler, **kwargs['subscribe'])
-    if not url or not isinstance(url, list):
-        crawler = get_crawler(subscriber, **kwargs)
-        crawler.crawl(url)
-    else:
-        url_list_kwargs = {k: kwargs[k] for k in kwargs if k != 'url'}
-        crawl_url_list(url, subscriber, **url_list_kwargs)
+        
+    if not urls or len(urls) == 0:
+        print("Cannot start crawling without (at least one) target url")
+        print("exiting...")
+        return
+
+    url_list_kwargs = {k: kwargs[k] for k in kwargs if k != 'url'}
+    crawl_url_list(urls, subscriber, **url_list_kwargs)
 
 
 def crawl_url_list(url, event_register=None, **kwargs):

--- a/lollygag/services/config_service.py
+++ b/lollygag/services/config_service.py
@@ -47,37 +47,29 @@ class ConfigService(object):
         """
         if not ConfigService.state:
             self.__init_args()
-            args = self.__parse_args()
-            for key in args:
-                ConfigService.state[key] = args[key]
-
-    def __parse_args(self):
-        arguments = self.argumentParser.parse_args()
-        config = {}
-        for key in DEFAULT_CONFIG:
-            attr = getattr(arguments, key, None)
-            if attr:
-                config[key] = attr
-            else:
-                config[key] = DEFAULT_CONFIG[key]
-        return config
+            args = self.argumentParser.parse_args().__dict__
+            ConfigService.state.update(args)
 
     def __init_args(self):
+        avail_logs = ["all", "debug", "info", "warn", "error", "none"]
         helps = {
             'urls': "Base url(s) you wish to crawl",
             'threads': "Maximum number of concurrent threads",
-            'loglevel': "Level of logging [all, info, debug, warn, error, none]",
-            'skip': "Regex patterns, when any of them is found in the url, it's skipped"
+            'loglevel': "Level of logging [{}]".format(", ".join(avail_logs)),
+            'skip': "Regex patterns, when any of them is found in the url, it's skipped",
+            'verify-ssl': "Certificates for https:// urls are verified"
         }
-        self.argumentParser.add_argument("--urls", "-u", nargs="+",
-                                         help=helps['urls'],
-                                         required=False)
-        self.argumentParser.add_argument("--threads", "-t",
-                                         help=helps['threads'],
-                                         required=False)
-        self.argumentParser.add_argument("--loglevel", "-l",
-                                         help=helps['loglevel'],
-                                         required=False)
+        self.argumentParser.add_argument("urls", nargs="*", metavar="urls", 
+                                         action="append", help=helps['urls'])
+        self.argumentParser.add_argument("--urls", "-u", nargs="*", metavar="urls", 
+                                         action="append", help=helps['urls'] + " (legacy)")
+
+        self.argumentParser.add_argument("--threads", "-t", nargs="?", const=int,
+                                         default=DEFAULT_CONFIG['threads'],
+                                         help=helps['threads'], required=False)
+        self.argumentParser.add_argument("--loglevel", "-l", choices=avail_logs,
+                                         default=DEFAULT_CONFIG['loglevel'],
+                                         help=helps['loglevel'], required=False)
         self.argumentParser.add_argument("--skip", "-s",
-                                         help=helps['skip'],
-                                         required=False)
+                                         default=DEFAULT_CONFIG['skip'],
+                                         help=helps['skip'], required=False)


### PR DESCRIPTION
Fixes #47

## Proposed Changes
  - `-u/--url` may be omitted for urls (but are still supported)
  - startup in main.run() simplified, `config.urls`,  case for one url handled now also handled by `main.crawl_url_list()`
  - `--loglevel/-l` only allows any of `["all", "debug", "info", "warn", "error", "none"]` 
  - `default` values in `config` handled with the built-in `argparse` mechanism
  - `-t/--threads` accepts only integers
  - removed `config_service.__parse_args()`, now provided out-of-the-box by `argparse`
